### PR TITLE
feat: update color palettes for accessibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,20 +6,20 @@
 /* Paleta 1: Azul/Verde (actual) */
 :root,
 .palette-1 {
-  --dark-navy: #020c1b;
-  --navy: #0a192f;
-  --light-navy: #112240;
-  --lightest-navy: #233554;
-  --navy-shadow: rgba(2, 12, 27, 0.7);
-  --dark-slate: #495670;
-  --slate: #8892b0;
-  --light-slate: #a8b2d1;
-  --lightest-slate: #ccd6f6;
-  --white: #e6f1ff;
-  --green: #64ffda;
-  --green-tint: rgba(100, 255, 218, 0.1);
-  --pink: #f57dff;
-  --blue: #57cbff;
+  --dark-navy: #0f172a;
+  --navy: #1e293b;
+  --light-navy: #334155;
+  --lightest-navy: #475569;
+  --navy-shadow: rgba(15, 23, 42, 0.7);
+  --dark-slate: #94a3b8;
+  --slate: #cbd5e1;
+  --light-slate: #e2e8f0;
+  --lightest-slate: #f1f5f9;
+  --white: #ffffff;
+  --green: #10b981;
+  --green-tint: rgba(16, 185, 129, 0.1);
+  --pink: #ec4899;
+  --blue: #3b82f6;
   --font-sans: 'Inter', 'San Francisco', 'SF Pro Text', -apple-system, system-ui, sans-serif;
   --font-mono: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
   --fz-xxs: 12px;
@@ -46,38 +46,38 @@
 
 /* Paleta 2: Tonos tierra */
 .palette-2 {
-  --dark-navy: #3e2723;
-  --navy: #5d4037;
-  --light-navy: #8d6e63;
-  --lightest-navy: #a1887f;
-  --navy-shadow: rgba(62, 39, 35, 0.7);
-  --dark-slate: #bcaaa4;
-  --slate: #d7ccc8;
-  --light-slate: #ffe0b2;
-  --lightest-slate: #fff8e1;
-  --white: #fffde7;
-  --green: #ff7043;
-  --green-tint: rgba(255, 112, 67, 0.1);
-  --pink: #ffab91;
-  --blue: #ffb300;
+  --dark-navy: #1c1917;
+  --navy: #292524;
+  --light-navy: #44403c;
+  --lightest-navy: #57534e;
+  --navy-shadow: rgba(28, 25, 23, 0.7);
+  --dark-slate: #a8a29e;
+  --slate: #d6d3d1;
+  --light-slate: #e7e5e4;
+  --lightest-slate: #f5f5f4;
+  --white: #fafaf9;
+  --green: #d97706;
+  --green-tint: rgba(217, 119, 6, 0.1);
+  --pink: #f97316;
+  --blue: #b45309;
 }
 
 /* Paleta 3: Pastel */
 .palette-3 {
-  --dark-navy: #b39ddb;
-  --navy: #9575cd;
-  --light-navy: #ce93d8;
-  --lightest-navy: #f8bbd0;
-  --navy-shadow: rgba(179, 157, 219, 0.7);
-  --dark-slate: #80cbc4;
-  --slate: #b2dfdb;
-  --light-slate: #b3e5fc;
-  --lightest-slate: #e1bee7;
-  --white: #fce4ec;
-  --green: #ffd54f;
-  --green-tint: rgba(255, 213, 79, 0.1);
-  --pink: #f8bbd0;
-  --blue: #81d4fa;
+  --dark-navy: #312e81;
+  --navy: #3730a3;
+  --light-navy: #4338ca;
+  --lightest-navy: #6366f1;
+  --navy-shadow: rgba(49, 46, 129, 0.7);
+  --dark-slate: #a5b4fc;
+  --slate: #c7d2fe;
+  --light-slate: #e0e7ff;
+  --lightest-slate: #eef2ff;
+  --white: #ffffff;
+  --green: #f472b6;
+  --green-tint: rgba(244, 114, 182, 0.1);
+  --pink: #f9a8d4;
+  --blue: #93c5fd;
 }
 
 /* Iconos de selección de paleta */


### PR DESCRIPTION
## Summary
- revise palette variables to use tailwind-friendly color scales
- improve contrast for better legibility across themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a96a847a488331b582a3aba28950c4